### PR TITLE
Allow for repos to build even without permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+main.aux
+main.log
+main.out
+main.pdf
+main.toc
+token
+main.fdb_latexmk
+main.fls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ services:
 - docker
 
 script:
-- docker run --rm -v $(pwd):/notes blang/latex /bin/bash -c "cd /notes; ./build.sh $NOTES_FILE"
-- "./test.sh $NOTES_FILE"
+- docker run --rm -v $(pwd):/notes blang/latex /bin/bash -c "cd /notes; latexmk -pdf $NOTES_FILE.tex"
 
 deploy:
   provider: releases

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-pdflatex -interaction=nonstopmode $1.tex
-pdflatex -interaction=nonstopmode $1.tex

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-[ -f $1.pdf ] && exit 0 || exit 1


### PR DESCRIPTION
To address the issues discussed in icl-notes/m2pm5#1 this removes the necessity for build scripts (or a `makefile` that would have solved the problem too by not requiring permissions but that are notorious bad practice for latex). 

What this does is simply invokes `latexmk` in the CI since it comes with the `blang/latex` docker image that we use and is simply more robust than invoking `pdflatex` manually.

